### PR TITLE
LPS-69571 add horizontal scroll buttons to carousel for more UX friendly scrolling

### DIFF
--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
@@ -14,7 +14,7 @@ import controlsTemplates from './EffectsControls.soy';
  * @private
  * @return {boolean} returns true if the carousel can be scrolled, false otherwise
  */
-canScrollForward() {
+function canScrollForward() {
 	const carousel = this.refs.carousel;
 	const continer = this.refs.carouselContainer;
 	const offset = Math.abs(parseInt(carousel.style.marginLeft || 0, 10));
@@ -187,9 +187,6 @@ class EffectsComponent extends Component {
 	 */ 
 	scrollLeft() {
 		const carousel = this.refs.carousel;
-		if (!carousel) {
-			return;
-		}
 		const itemWidth = this.res.carouselItem.offsetWidth || 0;
 		const marginLeft = parseInt(carousel.style.marginLeft || 0, 10);
 		if (marginLeft < 0) {

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
@@ -166,6 +166,96 @@ class EffectsComponent extends Component {
 	}
 
 	/**
+	 * Makes the caousel scroll left to reveal options off the visible area
+	 * 
+	 * @return void
+	 */ 
+	scrollLeft() {
+		const carousel = this.getCarouselElement();
+		if (!carousel) {
+			return;
+		}
+		const itemWidth = this.getCarouselItemElement().offsetWidth || 0;
+		const marginLeft = parseInt(carousel.style.marginLeft || 0, 10);
+		if (marginLeft < 0) {
+			const newMarginValue = Math.min(marginLeft + itemWidth, 0);
+			carousel.style.marginLeft =  newMarginValue + 'px';
+		}
+	}
+
+	/**
+	 * Makes the caousel scroll right to reveal options off the visible area
+	 * 
+	 * @return void
+	 */ 
+	scrollRight() {
+		const carousel = this.getCarouselElement();
+		if (!carousel) {
+			return;
+		}
+		if (!this.canScrollForward()) {
+			return;
+		}
+		const itemWidth = this.getCarouselItemElement().offsetWidth || 0;
+		const marginLeft = parseInt(carousel.style.marginLeft || 0, 10);
+		carousel.style.marginLeft = (marginLeft - itemWidth) + 'px';
+	}
+
+	/**
+	 * Returns the carousel element with lazy search
+	 * 
+	 * @return {DOMElement} element that incorporates content of the carousel
+	 */ 
+	getCarouselElement() {
+		if (!this.cache_.carouselElm) {
+			this.cache_.carouselElm = this.element.querySelector('#' + this.ref + '_carousel');
+		}
+		return this.cache_.carouselElm;
+	}
+
+	/**
+	 * Returns the first carousel item element with lazy search
+	 * 
+	 * @return {DOMElement} first child element of the carousel item. 
+	 * This is mainly fetched to get informations about the items the carousel
+	 * takes in.
+	 */ 
+	getCarouselItemElement() {
+		if (!this.cache_.carouselItemElm) {
+			const carousel = this.getCarouselElement() || {};
+			this.cache_.carouselItemElm = carousel.querySelector('li.item') || {};
+		}
+		return this.cache_.carouselItemElm;
+	}
+
+	/**
+	 * Returns the parent element of the carousel with lazy search
+	 * 
+	 * @return {DOMElement} element that incorporates the carousel
+	 */ 
+	getCarouselContainerElement() { 
+		if (!this.cache_.carouselContainerElm) {
+			const carousel = this.getCarouselElement();
+			this.cache_.carouselContainerElm = carousel.parentNode || carousel.parentElement;
+		}
+		return this.cache_.carouselContainerElm;
+	}
+
+	/**
+	 * Returns whether the carousel can be scrolled towards the right
+	 *
+	 * @return {boolean} returns true if the carousel can be scrolled, false otherwise
+	 */
+	canScrollForward() {
+		const carousel = this.getCarouselElement();
+		const continer = this.getCarouselContainerElement();
+		const offset = Math.abs(parseInt(carousel.style.marginLeft || 0, 10));
+		const viewportWidth = parseInt(continer.offsetWidth, 10);
+		const maxContentWidth = parseInt(carousel.offsetWidth, 10);
+		return offset + viewportWidth < maxContentWidth;
+	}
+
+	/**
 	 * Spawns the a webworker to do the image processing in a different thread.
 	 *
 	 * @param  {String} workerURI URI of the worker to spawn.

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
@@ -9,6 +9,21 @@ import componentTemplates from './EffectsComponent.soy';
 import controlsTemplates from './EffectsControls.soy';
 
 /**
+ * Returns whether the carousel can be scrolled towards the right
+ * 
+ * @private
+ * @return {boolean} returns true if the carousel can be scrolled, false otherwise
+ */
+canScrollForward() {
+	const carousel = this.refs.carousel;
+	const continer = this.refs.carouselContainer;
+	const offset = Math.abs(parseInt(carousel.style.marginLeft || 0, 10));
+	const viewportWidth = parseInt(continer.offsetWidth, 10);
+	const maxContentWidth = parseInt(carousel.offsetWidth, 10);
+	return offset + viewportWidth < maxContentWidth;
+}
+
+/**
  * Effects Component
  */
 class EffectsComponent extends Component {
@@ -166,20 +181,20 @@ class EffectsComponent extends Component {
 	}
 
 	/**
-	 * Makes the caousel scroll left to reveal options off the visible area
+	 * Makes the carousel scroll left to reveal options off the visible area
 	 * 
 	 * @return void
 	 */ 
 	scrollLeft() {
-		const carousel = this.getCarouselElement();
+		const carousel = this.refs.carousel;
 		if (!carousel) {
 			return;
 		}
-		const itemWidth = this.getCarouselItemElement().offsetWidth || 0;
+		const itemWidth = this.res.carouselItem.offsetWidth || 0;
 		const marginLeft = parseInt(carousel.style.marginLeft || 0, 10);
 		if (marginLeft < 0) {
 			const newMarginValue = Math.min(marginLeft + itemWidth, 0);
-			carousel.style.marginLeft =  newMarginValue + 'px';
+			this.carouselOffset =  newMarginValue + 'px';
 		}
 	}
 
@@ -189,70 +204,13 @@ class EffectsComponent extends Component {
 	 * @return void
 	 */ 
 	scrollRight() {
-		const carousel = this.getCarouselElement();
-		if (!carousel) {
+		const carousel = this.refs.carousel;
+		if (!canScrollForward.call(this)) {
 			return;
 		}
-		if (!this.canScrollForward()) {
-			return;
-		}
-		const itemWidth = this.getCarouselItemElement().offsetWidth || 0;
+		const itemWidth = this.refs.carouselItem.offsetWidth || 0;
 		const marginLeft = parseInt(carousel.style.marginLeft || 0, 10);
-		carousel.style.marginLeft = (marginLeft - itemWidth) + 'px';
-	}
-
-	/**
-	 * Returns the carousel element with lazy search
-	 * 
-	 * @return {DOMElement} element that incorporates content of the carousel
-	 */ 
-	getCarouselElement() {
-		if (!this.cache_.carouselElm) {
-			this.cache_.carouselElm = this.element.querySelector('#' + this.ref + '_carousel');
-		}
-		return this.cache_.carouselElm;
-	}
-
-	/**
-	 * Returns the first carousel item element with lazy search
-	 * 
-	 * @return {DOMElement} first child element of the carousel item. 
-	 * This is mainly fetched to get informations about the items the carousel
-	 * takes in.
-	 */ 
-	getCarouselItemElement() {
-		if (!this.cache_.carouselItemElm) {
-			const carousel = this.getCarouselElement() || {};
-			this.cache_.carouselItemElm = carousel.querySelector('li.item') || {};
-		}
-		return this.cache_.carouselItemElm;
-	}
-
-	/**
-	 * Returns the parent element of the carousel with lazy search
-	 * 
-	 * @return {DOMElement} element that incorporates the carousel
-	 */ 
-	getCarouselContainerElement() { 
-		if (!this.cache_.carouselContainerElm) {
-			const carousel = this.getCarouselElement();
-			this.cache_.carouselContainerElm = carousel.parentNode || carousel.parentElement;
-		}
-		return this.cache_.carouselContainerElm;
-	}
-
-	/**
-	 * Returns whether the carousel can be scrolled towards the right
-	 *
-	 * @return {boolean} returns true if the carousel can be scrolled, false otherwise
-	 */
-	canScrollForward() {
-		const carousel = this.getCarouselElement();
-		const continer = this.getCarouselContainerElement();
-		const offset = Math.abs(parseInt(carousel.style.marginLeft || 0, 10));
-		const viewportWidth = parseInt(continer.offsetWidth, 10);
-		const maxContentWidth = parseInt(carousel.offsetWidth, 10);
-		return offset + viewportWidth < maxContentWidth;
+		this.carouselOffset = (marginLeft - itemWidth) + 'px';
 	}
 
 	/**

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.es.js
@@ -187,7 +187,7 @@ class EffectsComponent extends Component {
 	 */ 
 	scrollLeft() {
 		const carousel = this.refs.carousel;
-		const itemWidth = this.res.carouselItem.offsetWidth || 0;
+		const itemWidth = this.res.carouselFirstItem.offsetWidth || 0;
 		const marginLeft = parseInt(carousel.style.marginLeft || 0, 10);
 		if (marginLeft < 0) {
 			const newMarginValue = Math.min(marginLeft + itemWidth, 0);
@@ -205,7 +205,7 @@ class EffectsComponent extends Component {
 		if (!canScrollForward.call(this)) {
 			return;
 		}
-		const itemWidth = this.refs.carouselItem.offsetWidth || 0;
+		const itemWidth = this.refs.carouselFirstItem.offsetWidth || 0;
 		const marginLeft = parseInt(carousel.style.marginLeft || 0, 10);
 		this.carouselOffset = (marginLeft - itemWidth) + 'px';
 	}
@@ -241,6 +241,15 @@ EffectsComponent.STATE = {
 	effects: {
 		validator: core.isArray,
 		value: ['none', 'ruby', 'absinthe', 'chroma', 'atari', 'tripel', 'ailis', 'flatfoot', 'pyrexia', 'umbra', 'rouge', 'idyll', 'glimmer', 'elysium', 'nucleus', 'amber', 'paella', 'aureus', 'expanse', 'orchid']
+	},
+
+	/**
+	 * Offset to the carousel item with the 'px' postfix 
+	 * @type {String}
+	 */
+	carouselOffset: {
+		validator: core.isString,
+		value: '0'		
 	},
 
 	/**

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.soy
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.soy
@@ -6,6 +6,7 @@
  * @param effects
  * @param ref
  * @param thumbnailSize
+ * @param carouselOffset
  * @param? currentEffect_
  * @param? pathThemeImages
  */
@@ -18,10 +19,10 @@
 				</svg>
 			</a>
 		</div>
-		<div class="carousel-container">
-			<ul class="carousel list-unstyled list-table" id="{$ref}_carousel">
+		<div class="carousel-container" ref="carouselContainer">
+			<ul class="carousel list-unstyled list-table" ref="carousel" style="margin-left: {$carouselOffset}">
 				{foreach $effect in $effects}
-					<li class="item">
+					<li class="item" {if isFirst($effect)}ref="carouselItem"{/if}>
 						<a data-onclick="previewEffect" data-effect="{$effect}" class="{$currentEffect_ == $effect ? 'active' : ''}">
 							<div id="{$ref}{$effect}" style="position: relative;">
 								<canvas width="{$thumbnailSize}" height="{$thumbnailSize}"></canvas>

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.soy
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.soy
@@ -22,7 +22,7 @@
 		<div class="carousel-container" ref="carouselContainer">
 			<ul class="carousel list-unstyled list-table" ref="carousel" style="margin-left: {$carouselOffset}">
 				{foreach $effect in $effects}
-					<li class="item" {if isFirst($effect)}ref="carouselItem"{/if}>
+					<li class="item" {if isFirst($effect)}ref="carouselFirstItem"{/if}>
 						<a data-onclick="previewEffect" data-effect="{$effect}" class="{$currentEffect_ == $effect ? 'active' : ''}">
 							<div id="{$ref}{$effect}" style="position: relative;">
 								<canvas width="{$thumbnailSize}" height="{$thumbnailSize}"></canvas>

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.soy
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-capability-effects/src/main/resources/META-INF/resources/EffectsComponent.soy
@@ -7,20 +7,37 @@
  * @param ref
  * @param thumbnailSize
  * @param? currentEffect_
+ * @param? pathThemeImages
  */
 {template .render}
-	<div id="{$ref}">
-		<ul class="carousel list-unstyled list-table">
-			{foreach $effect in $effects}
-				<li class="item">
-					<a data-onclick="previewEffect" data-effect="{$effect}" class="{$currentEffect_ == $effect ? 'active' : ''}">
-						<div id="{$ref}{$effect}" style="position: relative;">
-							<canvas width="{$thumbnailSize}" height="{$thumbnailSize}"></canvas>
-						</div>
-						<span>{$effect}</span>
-					</a>
-				</li>
-			{/foreach}
-		</ul>
+	<div class="carousel-wrapper" id="{$ref}">
+		<div class="carousel-left-arrow">
+			<a class="btn btn-link icon-monospaced" data-onclick="scrollLeft" href="javascript:;">
+				<svg class="lexicon-icon">
+					<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#angle-left"></use>
+				</svg>
+			</a>
+		</div>
+		<div class="carousel-container">
+			<ul class="carousel list-unstyled list-table" id="{$ref}_carousel">
+				{foreach $effect in $effects}
+					<li class="item">
+						<a data-onclick="previewEffect" data-effect="{$effect}" class="{$currentEffect_ == $effect ? 'active' : ''}">
+							<div id="{$ref}{$effect}" style="position: relative;">
+								<canvas width="{$thumbnailSize}" height="{$thumbnailSize}"></canvas>
+							</div>
+							<span>{$effect}</span>
+						</a>
+					</li>
+				{/foreach}
+			</ul>
+		</div>
+		<div class="carousel-right-arrow">
+			<a class="btn btn-link icon-monospaced" data-onclick="scrollRight" href="javascript:;">
+				<svg class="lexicon-icon">
+					<use xlink:href="{$pathThemeImages}/lexicon/icons.svg#angle-right"></use>
+				</svg>
+			</a>
+		</div>
 	</div>
 {/template}

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
@@ -103,7 +103,7 @@ $gray-lighter: lighten($gray-base, 93.5%) !default; // #EEE
 			}
 
 			.tool-controls {
-				overflow: hidden;
+				overflow: visible;
 				padding: 10px 0 0;
 
 				> * {
@@ -131,8 +131,41 @@ $gray-lighter: lighten($gray-base, 93.5%) !default; // #EEE
 					margin: 0 32px;
 				}
 
+				.carousel-wrapper {
+					position: relative;
+
+					.carousel-left-arrow,
+					.carousel-right-arrow {
+						position: absolute;
+						top: 50%;
+						z-index: 1;
+
+						.btn {
+							padding: 0;
+						}
+
+					}
+
+					.carousel-left-arrow {
+						left: 0;
+						@include transform(translate(-100%, -50%));
+					}
+
+					.carousel-right-arrow {
+						right: 0;
+						@include transform(translate(100%, -50%));
+					}
+
+				}
+
+				.carousel-container {
+					overflow: hidden;
+					width: 100%;
+				}
+
 				.carousel {
 					display: table;
+					@include transition(margin 0.6s $ease-out-quint);
 
 					.item {
 						display: table-cell;

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
@@ -148,11 +148,13 @@ $gray-lighter: lighten($gray-base, 93.5%) !default; // #EEE
 
 					.carousel-left-arrow {
 						left: 0;
+
 						@include transform(translate(-100%, -50%));
 					}
 
 					.carousel-right-arrow {
 						right: 0;
+						
 						@include transform(translate(100%, -50%));
 					}
 

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.scss
@@ -103,7 +103,7 @@ $gray-lighter: lighten($gray-base, 93.5%) !default; // #EEE
 			}
 
 			.tool-controls {
-				overflow: auto;
+				overflow: hidden;
 				padding: 10px 0 0;
 
 				> * {

--- a/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.soy
+++ b/modules/apps/foundation/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.soy
@@ -179,6 +179,7 @@
  * Renders the common Apply/Cancel buttons necessary for completing an image edition plus the
  * custom UI for the selected control
  *
+ * @param? pathThemeImages
  * @param control
  * @param selectedControl
  * @param strings


### PR DESCRIPTION
### Desclaimer 
This pull request addresses multiple issues that are in nature closely connected.
- Issue 1 is reported in https://issues.liferay.com/browse/LPS-69571
- Issue 2 is reported in https://issues.liferay.com/browse/LPS-66327

### Intent
To fix both issues above by updating the related CSS classes and adding scroll buttons to the Effect Tool Controls to enhance UX for horizontal scrolling.

### Solution
- Replaced `overflow:auto` with `overflow:visible` on the container element that includes the problematic content, thus the browser won't render the complementary scrollbars since there is no space restriction of the inner content.
- Added **Left** scroll button to the Effect Tool Controls section
- Added **Right** scroll button to the Effect Tool Controls section
- Provided functionality to make the Effect Carouse scroll horizontally when the buttons are clicked

### Test
Tested against:
- Edge
- FF
- Chrome
- Safari 

![captura de pantalla 2017-08-30 a las 14 44 37](https://user-images.githubusercontent.com/6104164/29873329-3a83115e-8d93-11e7-9804-feb721677f2c.png)
![lps-69571](https://user-images.githubusercontent.com/6104164/29968731-50ddd700-8f1d-11e7-887c-115115a6245d.gif)

