### PR TITLE
wip

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/build.gradle
@@ -74,6 +74,7 @@ dependencies {
 	compileOnly project(":apps:frontend-editor:frontend-editor-api")
 	compileOnly project(":apps:frontend-editor:frontend-editor-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-sql-dsl-api")

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorEditor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/CKEditorEditor.java
@@ -45,7 +45,7 @@ public class CKEditorEditor implements Editor, EditorRenderer {
 
 	@Override
 	public String getJspPath() {
-		return "/ckeditor.jsp";
+		return "/ckeditorreact.jsp";
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public class CKEditorEditor implements Editor, EditorRenderer {
 
 	@Override
 	public String getResourcesJspPath() {
-		return "/resources.jsp";
+		return "/resourcesreact.jsp";
 	}
 
 	@Override

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditorreact.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/ckeditorreact.jsp
@@ -1,0 +1,124 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+String portletId = portletDisplay.getRootPortletId();
+
+boolean autoCreate = GetterUtil.getBoolean((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":autoCreate"));
+String contents = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":contents");
+String cssClass = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":cssClass"));
+Map<String, Object> data = (Map<String, Object>)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":data");
+String editorName = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":editorName");
+String initMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":initMethod");
+boolean inlineEdit = GetterUtil.getBoolean((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":inlineEdit"));
+String inlineEditSaveURL = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":inlineEditSaveURL"));
+String name = GetterUtil.getString((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":name"));
+
+String onBlurMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onBlurMethod");
+
+if (Validator.isNotNull(onBlurMethod)) {
+	onBlurMethod = namespace + onBlurMethod;
+}
+
+String onChangeMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onChangeMethod");
+
+if (Validator.isNotNull(onChangeMethod)) {
+	onChangeMethod = namespace + onChangeMethod;
+}
+
+String onFocusMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onFocusMethod");
+
+if (Validator.isNotNull(onFocusMethod)) {
+	onFocusMethod = namespace + onFocusMethod;
+}
+
+String onInitMethod = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":onInitMethod");
+
+if (Validator.isNotNull(onInitMethod)) {
+	onInitMethod = namespace + onInitMethod;
+}
+
+boolean skipEditorLoading = GetterUtil.getBoolean((String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":skipEditorLoading"));
+String toolbarSet = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":toolbarSet");
+
+if (!inlineEdit) {
+	name = namespace + name;
+}
+
+JSONObject editorConfigJSONObject = null;
+
+if (data != null) {
+	editorConfigJSONObject = (JSONObject)data.get("editorConfig");
+}
+
+EditorOptions editorOptions = null;
+
+if (data != null) {
+	editorOptions = (EditorOptions)data.get("editorOptions");
+}
+
+Map<String, Object> editorOptionsDynamicAttributes = null;
+
+if (editorOptions != null) {
+	editorOptionsDynamicAttributes = editorOptions.getDynamicAttributes();
+}
+%>
+
+<c:if test="<%= !skipEditorLoading %>">
+	<liferay-editor:resources
+		editorName="<%= editorName %>"
+		inlineEdit="<%= inlineEdit %>"
+		inlineEditSaveURL="<%= inlineEditSaveURL %>"
+	/>
+</c:if>
+
+<%
+String textareaName = HtmlUtil.escapeAttribute(name);
+
+String modules = "aui-node-base";
+
+if (inlineEdit && Validator.isNotNull(inlineEditSaveURL)) {
+	textareaName = textareaName + "_original";
+
+	modules += ",inline-editor-ckeditor";
+}
+%>
+
+<%
+Map<String, Object> defaultEditorData = new HashMap<String, Object>();
+
+defaultEditorData.put("contents", contents);
+defaultEditorData.put("className", cssClass);
+defaultEditorData.put("editorConfig", Validator.isNotNull(editorConfigJSONObject) ? editorConfigJSONObject : "{}");
+defaultEditorData.put("editorName", editorName);
+defaultEditorData.put("editorOptions", data.get("editorOptions"));
+defaultEditorData.put("initialShowEditor", autoCreate);
+defaultEditorData.put("initialToolbarSet", TextFormatter.format(HtmlUtil.escapeJS(toolbarSet), TextFormatter.M));
+defaultEditorData.put("initMethod", initMethod);
+defaultEditorData.put("inlineEdit", inlineEdit);
+defaultEditorData.put("inlineEditSaveURL", inlineEditSaveURL);
+defaultEditorData.put("name", name);
+defaultEditorData.put("textareaName", textareaName);
+%>
+
+<div>
+	<react:component
+		data="<%= defaultEditorData %>"
+		module="editor/DefaultEditor"
+	/>
+</div>

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/DefaultEditor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/DefaultEditor.js
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React, {useEffect, useMemo, useRef, useState} from 'react';
+
+import {Editor} from './Editor';
+
+const DEFAULT_CONFIG = {
+	filebrowserBrowseUrl: '',
+	filebrowserFlashBrowseUrl: '',
+	filebrowserImageBrowseLinkUrl: '',
+	filebrowserImageBrowseUrl: '',
+	filebrowserUploadUrl: null
+};
+
+const getToolbarSet = toolbarSet => {
+	if (Liferay.Util.isPhone()) {
+		toolbarSet = 'phone';
+	}
+	else if (Liferay.Util.isTablet()) {
+		toolbarSet = 'tablet';
+	}
+
+	return toolbarSet;
+};
+
+const DefaultEditor = ({
+	className,
+	cssClass,
+	contents,
+	editorConfig,
+	editorName,
+	editorOptions,
+	initialShowEditor,
+	initialToolbarSet,
+	initMethod,
+	inlineEdit,
+	inlineEditSaveURL,
+	name,
+	textareaName,
+	toggleControlsStatus,
+}) => {
+	const editorRef = useRef();
+
+	const [toolbarSet, setToolbarSet] = useState();
+	const [showEditor, setShowEditor] = useState(initialShowEditor);
+
+	const config = useMemo(() => {
+		return {
+			...DEFAULT_CONFIG,
+			toolbar: toolbarSet,
+			...editorConfig,
+		}
+	}, [DEFAULT_CONFIG, editorConfig, toolbarSet]);
+
+	useEffect(() => {
+		setToolbarSet(getToolbarSet(initialToolbarSet));
+	}, [initialToolbarSet]);
+
+	useEffect(() => {
+		if (!window[name]) {
+			window[name] = {
+				getHTML() {
+					return editorRef.current.editor.getData();
+				},
+				getText() {
+					return editorRef.current.editor.getData();
+				},
+				setHTML(data) {
+					editorRef.current.editor.setData(data);
+				},
+			};
+		}
+
+		Liferay.on(`${name}selectItem`, event => {
+			CKEDITOR.tools.callFunction(event.ckeditorfuncnum, event.value);
+		});
+	}, []);
+
+	return (
+		<div className={cssClass} id={`${name}Container`}>
+			{showEditor &&
+				((inlineEdit && toggleControlsStatus === 'visible') ||
+					!inlineEdit) && (
+					<Editor
+						className="lfr-editable"
+						config={config}
+						data={contents}
+						id={name}
+						onBeforeLoad={CKEDITOR => {
+							CKEDITOR.disableAutoInline = true;
+							CKEDITOR.dtd.$removeEmpty.i = 0;
+							CKEDITOR.dtd.$removeEmpty.span = 0;
+						}}
+						ref={editorRef}
+						type={inlineEdit ? 'inline' : 'classic'}
+					/>
+				)}
+		</div>
+	);
+};
+
+export default DefaultEditor;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/editor/Editor.js
@@ -17,9 +17,9 @@ import React from 'react';
 
 const BASEPATH = '/o/frontend-editor-ckeditor-web/ckeditor/';
 
-const Editor = props => {
-	return <CKEditor {...props} />;
-};
+const Editor = React.forwardRef((props, ref) => {
+	return <CKEditor ref={ref} {...props} />;
+});
 
 CKEditor.editorUrl = `${BASEPATH}ckeditor.js`;
 window.CKEDITOR_BASEPATH = BASEPATH;

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/init.jsp
@@ -21,6 +21,7 @@
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/editor" prefix="liferay-editor" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
@@ -42,6 +43,7 @@ page import="com.liferay.portal.kernel.util.URLCodec" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>
 
+<%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resourcesreact.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/resourcesreact.jsp
@@ -1,0 +1,78 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+String editorName = (String)request.getAttribute(CKEditorConstants.ATTRIBUTE_NAMESPACE + ":editorName");
+%>
+
+<liferay-util:html-top
+	outputKey="js_editor_ckeditor_skip_editor_loading"
+>
+	<style type="text/css">
+		table.cke_dialog {
+			position: absolute !important;
+		}
+	</style>
+
+	<liferay-util:dynamic-include key='<%= "com.liferay.frontend.editor.ckeditor.web#" + editorName + "#additionalResources" %>' />
+
+	<script data-senna-track="temporary" type="text/javascript">
+		CKEDITOR.scriptLoader.loadScripts = function(scripts, success, failure) {
+			CKEDITOR.scriptLoader.load(scripts, success, failure);
+		};
+
+		CKEDITOR.getNextZIndex = function() {
+			return CKEDITOR.dialog._.currentZIndex
+				? CKEDITOR.dialog._.currentZIndex + 10
+				: Liferay.zIndex.WINDOW + 10;
+		};
+
+		var ckEditorDisposeResources = false;
+		var ckEditorInstances = 0;
+
+		var cleanupCkEditorResources = function() {
+			if (!ckEditorInstances && ckEditorDisposeResources) {
+				window.CKEDITOR = undefined;
+
+				ckEditorInstances = 0;
+				ckEditorDisposeResources = false;
+			}
+		};
+
+		Liferay.namespace('EDITORS').ckeditor = {
+			addInstance: function() {
+				ckEditorInstances++;
+			},
+			removeInstance: function() {
+				ckEditorInstances--;
+
+				cleanupCkEditorResources();
+			},
+		};
+
+		var destroyGlobalCkEditor = function() {
+			ckEditorDisposeResources = true;
+
+			cleanupCkEditorResources();
+
+			Liferay.detach('beforeScreenFlip', destroyGlobalCkEditor);
+		};
+
+		Liferay.on('beforeScreenFlip', destroyGlobalCkEditor);
+	</script>
+</liferay-util:html-top>


### PR DESCRIPTION
# Dudas generales

## Combinación React + CKEditor global

Aún utilizando CKEditor como componente de React, el objeto global CKEditor se expone (lo hace la propia librería) y se utiliza. Con lo cual al final tienes dos fuentes de cambio de información, via props del componente CKEditor y via API de la instancia que se crea. ¿Esto no podría ser peligroso? A parte de raro / inconsistente.

## API en window

Actualmente se está creando una API en window que es con la que se maneja la instancia del editor. Esto hay que adaptar cada método para trabajar con el nuevo uso de react.

## Dynamic includes

Existe un `dynamic-include` en mitad del método `createEditor`. Ya que este método no existe (o no se me ocurre cómo podría existir) en el nuevo componente React, ¿donde lo colocaríamos?

# Cambios realizados por el momento

## Textarea

Por lo que entendí el textarea que se pintaba era para compatibilidad en caso de que el editor no funcionara, pero en realidad nunca se ve, siempre tiene display:none y ni siquiera se le pone valor.  Además la implementación de React no usa un nodo para reemplazarlo sino que pinta el suyo propio. Por esto creo que sobra.

## autoCreate

Esta propiedad se usa para llamar directamente a createEditor o no. Cuando es false el editor solo se creará a través de la API en window. Debido al paradigma reactivo de react esto ya no tiene mucho sentido, simplemente se pintará o no.

## createEditor

En este método empieza la magia.

Lo primero que hace es comprobar si existe un nodo con el name pasado como id. De ser así ese será el nodo que reemplazará. Esto es especialmente importante para los inline ya que en React cambia el modo en que funciona. Ya no se especifica un nodo sobre el que hacer inline sino que se crea un editor igualmente, con type inline, y al que se le pasa como data el html de ese nodo.

En el caso de un editor normal, este nodo era el textarea que pintaba la jsp (ya que textareaName era === a name), y dando por sentado que un id debe ser único... para este caso nos da igual.

En el caso de un editor inline, este nodo NO era el textarea que pintaba la jsp (ya que textareaName era name + "_original"), por lo que no podemos estar seguros de que no se estuviera pasando un name (id) de un nodo ya existente y se usara para convertirlo en inline.

El problema viene precisamente de ahí, que el nodo en cuestión podía estar en cualquier sitio, mucho antes de la llamada a la tag del editor, y CKEDITOR simplemente cogía ese nodo y trabajaba sobre él, pero con la implementación en React esto no es así, la llamada a la tag debe estar en el lugar donde estaba el nodo, ya que ahí se pintará al no existir reemplazo.
      
Esta es una de las dudas principales. De momento vamos a obviar esto y simplemente vamos a envolver el editor en un div class="nameContainer" para mantener el mismo marcado.

Mi especulación es que todo esto de crear nodos / coger nodos es para controlar el tema de que no se creen los nodos cuando autoCreate es false y se llame al método `create` de la API en window en otro momento, manteniendo así el mismo marcado. Si esto es así... todo lo anterior nos lo ahorramos.

## Atributo contenteditable

Ya no es necesario ponerlo ya que el editor lo hace solo.
    
## Clase lfr-editable

Hay que analizar si es necesario. De momento se le pasa como className al editor.

## A.Do.after

`eventHandles.push(A.Do.after(afterVal, editorNode, 'val', this))`

Esto hace que cuando se llame al método "val" (que es propio de un nodo AUI), te devuelva en realidad el contenido del editor en vez de el del nodo. ¿Esto es necesario de verdad? Dado que ya que en teoría estamos eliminando los textareas y, creo, obviando nodos originales, diría que no.

# Conclusiones

No tengo muy claro si es que estoy haciendo más grande la pelota de lo que es y no he entendido el scope de la tarde, o es que es una tarea bastante inmensa con muchísimas variables.

Puede que me haya obcecado en la idea y no esté viéndolo de una manera más simple. Pedí ayuda a Julien por ello y tras trabajar juntos más o menos hemos llegado a las mismas conclusiones.

De todas formas, me ha costado bastante explicar esto por escrito, el lunes podemos organizar una llamada los tres para hablar de todo esto si os parece.

Gracias!