### PR TITLE
LPS-108824 Adds support for data-target as a trigger for the Collapsible plugin behaviour

### DIFF
--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
@@ -98,8 +98,7 @@ class CollapseProvider {
 
 		if (this._prefersReducedMotion()) {
 			onHidden();
-		}
-		else {
+		} else {
 			dom.once(panel, this._transitionEndEvent, onHidden);
 
 			panel.classList.add(CssClass.COLLAPSING);
@@ -167,8 +166,7 @@ class CollapseProvider {
 
 		if (this._prefersReducedMotion()) {
 			onShown();
-		}
-		else {
+		} else {
 			dom.once(panel, this._transitionEndEvent, onShown);
 
 			const capitalizedDimension =
@@ -186,7 +184,9 @@ class CollapseProvider {
 	}
 
 	_getPanel(trigger) {
-		return document.querySelector(trigger.getAttribute('href'));
+		return document.querySelector(
+			trigger.getAttribute('href') || trigger.dataset.target
+		);
 	}
 
 	_getTrigger(panel) {
@@ -205,8 +205,7 @@ class CollapseProvider {
 		if (panel) {
 			if (panel.classList.contains(CssClass.SHOW)) {
 				this.hide({panel, trigger});
-			}
-			else {
+			} else {
 				this.show({panel, trigger});
 			}
 		}

--- a/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
+++ b/modules/apps/frontend-js/frontend-js-collapse-support-web/src/main/resources/META-INF/resources/CollapseProvider.js
@@ -98,7 +98,8 @@ class CollapseProvider {
 
 		if (this._prefersReducedMotion()) {
 			onHidden();
-		} else {
+		}
+		else {
 			dom.once(panel, this._transitionEndEvent, onHidden);
 
 			panel.classList.add(CssClass.COLLAPSING);
@@ -166,7 +167,8 @@ class CollapseProvider {
 
 		if (this._prefersReducedMotion()) {
 			onShown();
-		} else {
+		}
+		else {
 			dom.once(panel, this._transitionEndEvent, onShown);
 
 			const capitalizedDimension =
@@ -205,7 +207,8 @@ class CollapseProvider {
 		if (panel) {
 			if (panel.classList.contains(CssClass.SHOW)) {
 				this.hide({panel, trigger});
-			} else {
+			}
+			else {
 				this.show({panel, trigger});
 			}
 		}


### PR DESCRIPTION
Pretty self-explanatory fix for [Mobile menu button doesn't work in Classic theme](https://issues.liferay.com/browse/LPS-108824)

**Step to reproduce:**
- Go to the Home page
- Reduce the windows until the mobile menu button appears
- Click on the mobile menu button

**Expected Results:**
The menu is opened

The menu trigger is not a link `<a>` but a `<button>` and thus, it has no `href`, so `CollapseProvider::_getPanel` fails to locate the panel Id.


![Jun-08-2020 17-07-08](https://user-images.githubusercontent.com/5803434/84046549-89397500-a9aa-11ea-8580-ff5fd91ed1a9.gif)
